### PR TITLE
Fix typo in check_data MLproject

### DIFF
--- a/check_data/MLproject
+++ b/check_data/MLproject
@@ -5,10 +5,10 @@ entry_points:
   main:
     parameters:
       reference_artifact:
-        description: Fully-qualitied name for the artifact to be used as reference dataset
+        description: Fully-qualified name for the artifact to be used as reference dataset
         type: str
       sample_artifact:
-        description: Fully-qualitied name for the artifact to be used as new data sample
+        description: Fully-qualified name for the artifact to be used as new data sample
         type: str
       ks_alpha:
         description: Threshold for the (pre-trial) p-value for the KS test


### PR DESCRIPTION
## Summary
- correct minor typo in `check_data/MLproject`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68400f058c7883309e88d5d690564760